### PR TITLE
Add method to retrieve details for ConsumptionUnits

### DIFF
--- a/src/pyecotrend_ista/const.py
+++ b/src/pyecotrend_ista/const.py
@@ -3,6 +3,7 @@ VERSION = "3.0.0"
 BASE_URL = "https://api.prod.eed.ista.com/"
 ACCOUNT_URL = BASE_URL + "account"
 CONSUMPTIONS_URL = BASE_URL + "consumptions?consumptionUnitUuid="
+CONSUMPTION_UNIT_DETAILS_URL = BASE_URL + "menu"
 
 PROVIDER_URL = "https://keycloak.ista.com/realms/eed-prod/protocol/openid-connect/"
 REDIRECT_URI = "https://ecotrend.ista.de/login-redirect"

--- a/src/pyecotrend_ista/pyecotrend_ista.py
+++ b/src/pyecotrend_ista/pyecotrend_ista.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import requests
 
-from .const import ACCOUNT_URL, CONSUMPTIONS_URL, MAX_RETRIES, RETRY_DELAY, VERSION
+from .const import ACCOUNT_URL, CONSUMPTIONS_URL, MAX_RETRIES, RETRY_DELAY, VERSION, CONSUMPTION_UNIT_DETAILS_URL
 from .exception_classes import Error, InternalServerError, LoginError, ServerError
 from .helper_object_de import CustomRaw
 from .login_helper import LoginHelper
@@ -570,6 +570,21 @@ class PyEcotrendIsta:
             except requests.JSONDecodeError as err:
                 self._LOGGER.debug("JSONDecodeError", err)
         return raw
+    
+    def get_consumption_unit_details(self) -> dict[str, Any]:
+        """Get consumption unit details."""
+        try:
+            with self.session.get(CONSUMPTION_UNIT_DETAILS_URL, headers=self._header) as r:
+                r.raise_for_status()
+                try:
+                    return r.json()
+                except requests.JSONDecodeError as e:
+                    self._LOGGER.debug("JSONDecodeError: %s", e)
+                    raise ServerError from e
+        except (requests.RequestException, requests.Timeout) as e:
+            self._LOGGER.debug("RequestException: %s", e)
+            raise ServerError from e
+
 
     def getSupportCode(self) -> str | None:
         """Returns the support code associated with the instance."""


### PR DESCRIPTION
Adds a method to retrieve details for ConsumptionUnits like address. 

```
{
    "consumptionUnits": [
        {
            "id": "26e93f1a-c828-11ea-87d0-0242ac130003",
            "address": {
                "street": "Luxemburger Str.",
                "houseNumber": "1",
                "postalCode": "45131",
                "city": "Essen",
                "country": "DE",
                "floor": "2. OG links",
                "propertyNumber": "112233445",
                "consumptionUnitNumber": "0001",
                "idAtCustomerUser": "6234XB"
            },
            "booked": {
                "cost": true,
                "co2": false
            },
            "propertyNumber": "57352474"
        }
    ],
    "coBranding": null
}
```