### PR TITLE
Unpin requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-dataclasses-json==0.6.6
-requests==2.31.0
+dataclasses-json>=0.6
+requests>=2


### PR DESCRIPTION
Too strictly pinned requirements will often cause dependency conflicts. Pinning requirements to a main version or a minimum version ensures the library doesn't break again if for example Home Assistant upgrades their dependencies in future releases.