### PR TITLE
Add linting settings, add docstrings to login helper and PyEcotrendIsta client

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,14 @@
+line-length = 100
+indent-width = 4
+target-version = "py311"
+
+[lint]
+extend-select = ["I", "TRY", "UP", "D", "W"]
+extend-ignore = ["D213", "D202", "D203", "D213", "UP038"]
+
+[lint.pydocstyle]
+convention = "numpy"
+
+[format]
+quote-style = "double"
+indent-style = "space"

--- a/src/pyecotrend_ista/pyecotrend_ista.py
+++ b/src/pyecotrend_ista/pyecotrend_ista.py
@@ -1,7 +1,10 @@
+"""Unofficial python library for the ista EcoTrend API."""
+
 from __future__ import annotations
 
 import logging
 import time
+import warnings
 from typing import Any
 
 import requests
@@ -21,6 +24,11 @@ from .login_helper import LoginHelper
 
 
 class PyEcotrendIsta:
+    """A Python client for interacting with the ista EcoTrend API.
+
+    This class provides methods to authenticate and interact with the ista EcoTrend API.
+    """
+
     def __init__(
         self,
         email: str,
@@ -30,6 +38,28 @@ class PyEcotrendIsta:
         totp: str | None = None,
         session: requests.Session | None = None,
     ) -> None:
+        """Initialize the PyEcotrendIsta client.
+
+        Parameters
+        ----------
+        email : str
+            The email address used to log in to the ista EcoTrend API.
+        password : str
+            The password used to log in to the ista EcoTrend API.
+        logger : logging.Logger, optional
+            An optional logger instance for logging messages. Default is None.
+        hass_dir : str, optional
+            [DEPRECATED] An optional directory for Home Assistant configuration. Default is None.
+        totp : str, optional
+            An optional TOTP (Time-based One-Time Password) for two-factor authentication. Default is None.
+        session : requests.Session, optional
+            An optional requests session for making HTTP requests. Default is None.
+
+        """
+
+        if hass_dir:
+            warnings.warn("The 'hass_dir' parameter is deprecated and will be removed in a future release.", DeprecationWarning)
+
         self._accessToken: str | None = None
         self._refreshToken: str | None = None
         self._accessTokenExpiresIn: int = 0
@@ -53,6 +83,22 @@ class PyEcotrendIsta:
 
     @property
     def accessToken(self):
+        """Retrieve the access token, refreshing it if necessary.
+
+        This property checks if the access token is still valid. If the token has expired and the client is connected,
+        it refreshes the token. The token is considered expired if the current time minus the start time exceeds the
+        token's expiration period.
+
+        Returns
+        -------
+        str
+            The current access token.
+
+        Notes
+        -----
+        This method will automatically refresh the access token if it has expired.
+
+        """
         if (
             self._accessTokenExpiresIn > 0
             and self._isConnected()
@@ -63,14 +109,42 @@ class PyEcotrendIsta:
         return self._accessToken
 
     def _isConnected(self) -> bool:
+        """Check if the client is connected by verifying the presence of an access token.
+
+        Returns
+        -------
+        bool
+            True if the client has a valid access token, False otherwise.
+
+        """
         if self._accessToken:
             return True
         return False
 
     def _logoff(self) -> None:
+        """Log off the client by invalidating the current access token.
+
+        This method sets the access token to None, effectively logging off the client.
+        """
         self._accessToken = None
 
     def __login(self, debug: bool = False) -> str | None:
+        """Perform the login process to obtain an access token.
+
+        If the email is a demo account, it logs in using a demo user login function.
+        For other accounts, it retrieves a token using a login helper.
+
+        Parameters
+        ----------
+        debug : bool, optional
+            [DEPRECATED] Whether to enable debug logging. Default is False.
+
+        Returns
+        -------
+        str or None
+            The access token if login is successful, None otherwise.
+
+        """
         if self._email == "demo@ista.de":
             self._LOGGER.debug("DEMO")
             token = self.demo_user_login()
@@ -82,6 +156,16 @@ class PyEcotrendIsta:
         return self.accessToken
 
     def __refresh(self) -> None:
+        """Refresh the access token using the refresh token.
+
+        This method retrieves a new access token, updates internal variables,
+        and resets the token expiration timer.
+
+        Notes
+        -----
+        This method assumes `self._refreshToken` is already set.
+
+        """
         self._accessToken, self._accessTokenExpiresIn, self._refreshToken = self.loginhelper.refreshToken(self._refreshToken)
         new_token = self._accessToken
 
@@ -89,7 +173,19 @@ class PyEcotrendIsta:
         self.start_timer = time.time()
         self._LOGGER.debug("refresh Token %s", self.start_timer)
 
-    def __setAccountValues(self, res_json) -> None:
+    def __setAccountValues(self, res_json: dict[str, Any]) -> None:
+        """Set account values based on the provided JSON response.
+
+        Parameters
+        ----------
+        res_json : dict
+            JSON response containing account information.
+
+        Notes
+        -----
+        Sets instance variables for various account details based on keys in `res_json`.
+
+        """
         self._a_ads = res_json["ads"]
         self._a_authcode = res_json["authcode"]
         self._a_betaPhase = res_json["betaPhase"]
@@ -121,6 +217,11 @@ class PyEcotrendIsta:
         self._uuid = res_json["activeConsumptionUnit"]  # single
 
     def __setAccount(self) -> None:
+        """Fetch and set account information from the API.
+
+        This method performs an API request to retrieve account information
+        and sets instance variables accordingly using __setAccountValues.
+        """
         self._header = {"Content-Type": "application/json"}
         self._header["User-Agent"] = self.getUA()
         self._header["Authorization"] = f"Bearer {self.accessToken}"
@@ -129,9 +230,46 @@ class PyEcotrendIsta:
         self.__setAccountValues(res)
 
     def getVersion(self) -> str:
+        """Get the version of the PyEcotrendIsta client.
+
+        Returns
+        -------
+        str
+            The version number of the PyEcotrendIsta client.
+
+        """
         return VERSION
 
     def login(self, forceLogin: bool = False, debug: bool = False) -> str | None:
+        """Perform the login process if not already connected or forced.
+
+        Parameters
+        ----------
+        forceLogin : bool, optional
+            If True, forces a fresh login attempt even if already connected. Default is False.
+        debug : bool, optional
+            [DEPRECATED] Flag indicating whether to enable debug logging. Default is False.
+
+        Returns
+        -------
+        str or None
+            The access token if login is successful, None otherwise.
+
+        Raises
+        ------
+        LoginError
+            If the login process fails due to an error.
+        ServerError
+            If a server error occurs during login attempts.
+        InternalServerError
+            If an internal server error occurs during login attempts.
+        Exception
+            For any other unexpected errors during the login process.
+
+        """
+        if debug:
+            warnings.warn("The 'debug' parameter is deprecated and will be removed in a future release.", DeprecationWarning)
+
         self.start_timer = time.time()
         if not self._isConnected() or forceLogin:
             self._logoff()
@@ -163,12 +301,85 @@ class PyEcotrendIsta:
         return self.accessToken
 
     def userinfo(self, token):
+        """Retrieve user information using the provided access token.
+
+        Parameters
+        ----------
+        token : str
+            The access token used for authentication.
+
+        Returns
+        -------
+        Any
+            JSON response containing user information.
+
+        Notes
+        -----
+        This method constructs an authorization header using the provided access token
+        and sends a GET request to the userinfo endpoint of the provider API.
+        It expects a JSON response with user information.
+
+        Raises
+        ------
+        requests.exceptions.RequestException
+            If an error occurs while making the HTTP request.
+
+        Example
+        -------
+        >>> client = PyEcotrendIsta(email='user@example.com', password='password')
+        >>> token = client.login()
+        >>> user_info = client.userinfo(token)
+
+        """
         return self.loginhelper.userinfo(token=token)
 
     def logout(self) -> None:
+        """Perform logout operation by invalidating the current session.
+
+        This method invokes the logout functionality in the loginhelper module,
+        passing the current refresh token for session invalidation.
+
+        Notes
+        -----
+        This method assumes `self._refreshToken` is already set.
+
+        Raises
+        ------
+        KeycloakPostError
+            If an error occurs during the logout process. This error is raised based on the response from the logout request.
+
+        Example:
+        -------
+        >>> client = PyEcotrendIsta(email='user@example.com', password='password')
+        >>> client.login()
+        >>> client.logout()
+
+        """
         self.loginhelper.logout(self._refreshToken)
 
     def getUUIDs(self) -> list[str]:
+        """Retrieve UUIDs of consumption units registered in the account.
+
+        Returns
+        -------
+        list[str]
+            A list containing UUIDs of consumption units. Each UUID represents a consumption unit,
+            which could be a flat or a house for which consumption readings are provided.
+
+        Notes
+        -----
+        A consumption unit represents a residence or building where consumption readings are recorded.
+        The UUIDs are extracted from the `_residentAndConsumptionUuidsMap` attribute.
+
+        Example:
+        -------
+        >>> client = PyEcotrendIsta(email='user@example.com', password='password')
+        >>> client.login()
+        >>> uuids = client.getUUIDs()
+        >>> print(uuids)
+        ['uuid1', 'uuid2', 'uuid3']
+
+        """
         uuids = []
         for _, value in self._residentAndConsumptionUuidsMap.items():
             uuids.append(value)
@@ -176,8 +387,43 @@ class PyEcotrendIsta:
 
     # @refresh_now
     def consum_raw(  # noqa: C901
-        self, select_year=None, select_month=None, filter_none=True, obj_uuid: str | None = None
+        self,
+        select_year: list[int] | None = None,
+        select_month: list[int] | None = None,
+        filter_none: bool = True,
+        obj_uuid: str | None = None,
     ) -> dict[str, Any]:  # noqa: C901
+        """Process consumption and cost data for a given consumption unit.
+
+        Parameters
+        ----------
+        select_year : list[int] | None, optional
+            List of years to filter data by year, default is None.
+        select_month : list[int] | None, optional
+            List of months to filter data by month, default is None.
+        filter_none : bool, optional
+            Whether to filter out None values in readings, default is True.
+        obj_uuid : str | None, optional
+            UUID of the consumption unit to fetch data for, default is None.
+
+        Returns
+        -------
+        dict[str, Any]
+            Processed data including consumption types, total additional values, last values,
+            last costs, sum by year, and last year compared consumption.
+
+        Notes
+        -----
+        This method processes raw consumption and cost data obtained from the `_get_raw` method.
+        It filters and aggregates data based on the parameters provided.
+
+        Raises
+        ------
+        Exception
+            If there is an unexpected error during data processing.
+
+        """
+        # Fetch raw consumption data for the specified UUID
         c_raw: dict[str, Any] = self.get_raw(obj_uuid)
 
         if not isinstance(c_raw, dict) or (c_raw.get("consumptions", None) is None and c_raw.get("costs", None) is None):
@@ -547,6 +793,25 @@ class PyEcotrendIsta:
         ).to_dict()
 
     def get_raw(self, obj_uuid: str | None = None) -> dict[str, Any]:
+        """Fetch raw consumption data from the API for a specific consumption unit.
+
+        Parameters
+        ----------
+        obj_uuid : str, optional
+            The UUID of the consumption unit. If not provided,
+            defaults to the UUID associated with the instance (`self._uuid`).
+
+        Returns
+        -------
+        dict
+            A dictionary containing the raw consumption data fetched from the API.
+
+        Raises
+        ------
+        LoginError
+            If the API responds with an error indicating login failure or invalid input.
+
+        """
         raw: dict[str, Any] = {}
 
         if obj_uuid is None:
@@ -566,7 +831,20 @@ class PyEcotrendIsta:
         return raw
 
     def get_consumption_unit_details(self) -> dict[str, Any]:
-        """Get consumption unit details."""
+        """Retrieve details of the consumption unit from the API.
+
+        Returns
+        -------
+        dict
+            A dictionary containing the details of the consumption unit.
+
+        Raises
+        ------
+        ServerError
+            If there is an issue with decoding the JSON response or if any request-related
+            exceptions occur (e.g., network issues, timeouts).
+
+        """
         try:
             with self.session.get(CONSUMPTION_UNIT_DETAILS_URL, headers=self._header) as r:
                 r.raise_for_status()
@@ -580,18 +858,49 @@ class PyEcotrendIsta:
             raise ServerError from e
 
     def getSupportCode(self) -> str | None:
-        """Returns the support code associated with the instance."""
+        """Return the support code associated with the instance.
+
+        Returns
+        -------
+        str or None
+            The support code associated with the instance, or None if not set.
+
+        """
         return self._supportCode
 
     def getUA(self) -> str:
-        """Set User-Agent string."""
+        """Return the User-Agent string used for HTTP requests.
+
+        Returns
+        -------
+        str
+            The User-Agent string.
+
+        Notes
+        -----
+        This method provides a static User-Agent string commonly used for web browsers.
+
+        """
         return (
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.67"
             " Safari/537.36"
         )
 
     def demo_user_login(self) -> dict[str, Any]:
-        """Retrieve authentication tokens for demo user."""
+        """Retrieve authentication tokens for the demo user.
+
+        Returns
+        -------
+        dict[str, Any]
+            A dictionary containing authentication tokens including 'accessToken',
+            'accessTokenExpiresIn', and 'refreshToken'.
+
+        Raises
+        ------
+        ServerError
+            If there is an issue with the server response or decoding JSON data.
+
+        """
         try:
             self._header["User-Agent"] = self.getUA()
             with self.session.get(DEMO_USER_TOKEN, headers=self._header, ) as r:


### PR DESCRIPTION
- Added a new configuration file `ruff.toml` specifying line length, indentation, target Python version, and some basic linting rules.
- Refactored `login_helper.py`:
  - Renamed module docstring to describe its usage with Keycloak.
  - Added docstrings for better clarity and documentation.
- Updated `pyecotrend_ista.py`:
  - Enhanced docstrings and added deprecated warnings for `debug` and `hass_dir` parameters.
  - Added explicit type hints were missing and improved method documentation.