### PR TITLE
Remove black pre-commit hook and update ruff configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,14 +28,6 @@ repos:
           - "--remove-duplicate-keys"
           - "--remove-unused-variables"
           - "--remove-all-unused-imports"
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
-    hooks:
-      - id: black
-        args:
-          - --line-length=127
-          - --quiet
-        files: ^((src|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:

--- a/ruff.toml
+++ b/ruff.toml
@@ -12,3 +12,11 @@ convention = "numpy"
 [format]
 quote-style = "double"
 indent-style = "space"
+
+[lint.isort]
+force-sort-within-sections = true
+known-first-party = [
+    "pyecotrend_ista",
+]
+combine-as-imports = true
+split-on-trailing-comma = false


### PR DESCRIPTION
- Updated ruff.toml to include isort configuration:
  - Force sort within sections.
  - Recognize known first-party imports.
  - Combine as imports.
  - Do not split on trailing comma.
- Removed the black pre-commit hook from .pre-commit-config.yaml. as it conflicts with ruffs imports sorting