### PR TITLE
Rename `get_raw` method to `get_cunsumption_data`

### DIFF
--- a/src/pyecotrend_ista/exception_classes.py
+++ b/src/pyecotrend_ista/exception_classes.py
@@ -30,7 +30,10 @@ def deprecated(func: Callable[..., T], alias_func: str | None = None) -> Callabl
 
     def deprecated_func(*args, **kwargs):
         if alias_func:
-            warning_message = f"The `{alias_func}` function is deprecated and will be removed in a future release. Use `{func.__name__}` instead."
+            warning_message = (
+                f"The `{alias_func}` function is deprecated and will be removed in a future release. "
+                f"Use `{func.__name__}` instead."
+            )
         else:
             warning_message = f"The `{func.__name__}` function is deprecated and will be removed in a future release."
 
@@ -110,7 +113,7 @@ class ParserError(ServerError):
 
 # Source from https://github.com/marcospereirampj/python-keycloak/blob/c98189ca6951f12f1023ed3370c9aaa0d81e4aa4/src/keycloak/exceptions.py
 
-"""Keycloak custom exceptions module."""
+# Keycloak custom exceptions module.
 
 
 class KeycloakError(Exception):

--- a/src/pyecotrend_ista/pyecotrend_ista.py
+++ b/src/pyecotrend_ista/pyecotrend_ista.py
@@ -428,7 +428,7 @@ class PyEcotrendIsta:
 
         Notes
         -----
-        This method processes raw consumption and cost data obtained from the `_get_raw` method.
+        This method processes consumption and cost data obtained from the `get_consumption_data` method.
         It filters and aggregates data based on the parameters provided.
 
         Raises
@@ -437,8 +437,8 @@ class PyEcotrendIsta:
             If there is an unexpected error during data processing.
 
         """
-        # Fetch raw consumption data for the specified UUID
-        c_raw: dict[str, Any] = self.get_raw(obj_uuid)
+        # Fetch consumption data for the specified UUID
+        c_raw: dict[str, Any] = self.get_comsumption_data(obj_uuid)
 
         if not isinstance(c_raw, dict) or (c_raw.get("consumptions", None) is None and c_raw.get("costs", None) is None):
             return c_raw
@@ -806,8 +806,8 @@ class PyEcotrendIsta:
             }
         ).to_dict()
 
-    def get_raw(self, obj_uuid: str | None = None) -> dict[str, Any]:
-        """Fetch raw consumption data from the API for a specific consumption unit.
+    def get_comsumption_data(self, obj_uuid: str | None = None) -> dict[str, Any]:
+        """Fetch consumption data from the API for a specific consumption unit.
 
         Parameters
         ----------
@@ -818,7 +818,7 @@ class PyEcotrendIsta:
         Returns
         -------
         dict
-            A dictionary containing the raw consumption data fetched from the API.
+            A dictionary containing the consumption data fetched from the API.
 
         Raises
         ------
@@ -862,6 +862,7 @@ class PyEcotrendIsta:
         except requests.RequestException as exc:
             raise ServerError("Loading consumption data failed due to a request exception") from exc
 
+    get_raw = deprecated(get_comsumption_data, "get_raw")
 
     def get_consumption_unit_details(self) -> dict[str, Any]:
         """Retrieve details of the consumption unit from the API.

--- a/tests/__snapshots__/test_consumptions.ambr
+++ b/tests/__snapshots__/test_consumptions.ambr
@@ -81,7 +81,7 @@
     }),
   })
 # ---
-# name: test_get_raw
+# name: test_get_comsumption_data
   dict({
     'co2Emissions': None,
     'co2EmissionsBillingPeriods': None,

--- a/tests/test_consumptions.py
+++ b/tests/test_consumptions.py
@@ -12,12 +12,12 @@ from pyecotrend_ista import LoginError, ParserError, PyEcotrendIsta, ServerError
 from pyecotrend_ista.const import API_BASE_URL
 
 
-def test_get_raw(ista_client: PyEcotrendIsta, requests_mock: RequestsMock, snapshot: SnapshotAssertion, dataset) -> None:
+def test_get_comsumption_data(ista_client: PyEcotrendIsta, requests_mock: RequestsMock, snapshot: SnapshotAssertion, dataset) -> None:
     """Test `_set_account` method."""
 
     requests_mock.get(f"{API_BASE_URL}consumptions", json=dataset["test_data"])
 
-    assert ista_client.get_raw("26e93f1a-c828-11ea-87d0-0242ac130003") == snapshot
+    assert ista_client.get_comsumption_data("26e93f1a-c828-11ea-87d0-0242ac130003") == snapshot
 
 
 @pytest.mark.parametrize(
@@ -31,7 +31,7 @@ def test_get_raw(ista_client: PyEcotrendIsta, requests_mock: RequestsMock, snaps
         ]
     ),
 )
-def test_get_raw_http_errors(
+def test_get_comsumption_data_http_errors(
     requests_mock: RequestsMock, ista_client: PyEcotrendIsta, status_code: HTTPStatus, expected_exception
 ) -> None:
     """Test Login method."""
@@ -42,13 +42,13 @@ def test_get_raw_http_errors(
     )
 
     with pytest.raises(expected_exception=expected_exception):
-        ista_client.get_raw("26e93f1a-c828-11ea-87d0-0242ac130003")
+        ista_client.get_comsumption_data("26e93f1a-c828-11ea-87d0-0242ac130003")
 
 
 @pytest.mark.parametrize(
     ("exception", "expected_exception"), ([(requests.RequestException, ServerError), (requests.Timeout, ServerError)])
 )
-def test_get_raw_exceptions(requests_mock: RequestsMock, ista_client: PyEcotrendIsta, exception, expected_exception) -> None:
+def test_get_comsumption_data_exceptions(requests_mock: RequestsMock, ista_client: PyEcotrendIsta, exception, expected_exception) -> None:
     """Test Login method."""
 
     requests_mock.get(
@@ -56,7 +56,7 @@ def test_get_raw_exceptions(requests_mock: RequestsMock, ista_client: PyEcotrend
     )
 
     with pytest.raises(expected_exception=expected_exception):
-        ista_client.get_raw("26e93f1a-c828-11ea-87d0-0242ac130003")
+        ista_client.get_comsumption_data("26e93f1a-c828-11ea-87d0-0242ac130003")
 
 
 def test_consum_raw(ista_client: PyEcotrendIsta, requests_mock: RequestsMock, snapshot: SnapshotAssertion, dataset) -> None:


### PR DESCRIPTION
- Renamed `get_raw` method to `get_comsumption_data` in `PyEcotrendIsta` class to clarify its purpose of fetching consumption data from the API.
- Updated method docstring and usage to reflect its purpose of fetching consumption data.
- Introduced deprecation warning for `get_raw` method usage.
- Updated tests in `test_consumptions.py` to accommodate method name change (`get_raw` -> `get_comsumption_data`).
- Ensured backward compatibility with existing method through deprecation decorator.