### PR TITLE
Fix merge issues and correct minor bugs

### DIFF
--- a/src/pyecotrend_ista/pyecotrend_ista.py
+++ b/src/pyecotrend_ista/pyecotrend_ista.py
@@ -200,8 +200,19 @@ class PyEcotrendIsta:
     def __set_account(self) -> None:
         """Fetch and set account information from the API.
 
-        This method performs an API request to retrieve account information
-        and sets instance variables accordingly using __set_account_values.
+         This method performs an API request to retrieve account information,
+        handles various potential errors that might occur during the request,
+        and sets instance variables accordingly using the response data.
+
+        Raises
+        ------
+        ParserError
+            If there is an error parsing the JSON response.
+        LoginError
+            If the request fails due to an authorization error.
+        ServerError
+            If the request fails due to a server error, timeout, or other request exceptions.
+
         """
         self._header = {
             "Content-Type": "application/json",
@@ -258,6 +269,8 @@ class PyEcotrendIsta:
             If True, forces a fresh login attempt even if already connected. Default is False.
         debug : bool, optional
             [DEPRECATED] Flag indicating whether to enable debug logging. Default is False.
+        forceLogin : bool, optional
+            [DEPRECATED] Use `force_login` instead.
 
         Returns
         -------
@@ -415,7 +428,7 @@ class PyEcotrendIsta:
 
         Returns
         -------
-        dict[str, Any]
+        dict[str, Any] | ConsumptionsResponse
             Processed data including consumption types, total additional values, last values,
             last costs, sum by year, and last year compared consumption.
 
@@ -799,7 +812,7 @@ class PyEcotrendIsta:
             }
         ).to_dict()
 
-    def get_comsumption_data(self, obj_uuid: str | None = None) -> dict[str, Any]:
+    def get_comsumption_data(self, obj_uuid: str | None = None) -> ConsumptionsResponse:
         """Fetch consumption data from the API for a specific consumption unit.
 
         Parameters
@@ -810,7 +823,7 @@ class PyEcotrendIsta:
 
         Returns
         -------
-        dict
+        ConsumptionsResponse
             A dictionary containing the consumption data fetched from the API.
 
         Raises
@@ -910,7 +923,7 @@ class PyEcotrendIsta:
             The support code associated with the instance, or None if not set.
 
         """
-        return self._support_code
+        return getattr(self, "_account", {}).get("supportCode")
 
     getSupportCode = deprecated(get_support_code, "getSupportCode")  # noqa: N815
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -36,12 +36,19 @@ def test_get_user_agent(ista_client: PyEcotrendIsta) -> None:
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.67"
         " Safari/537.36"
     )
-@pytest.mark.xfail
+
 @pytest.mark.usefixtures("mock_requests_login")
 def test_get_support_code(ista_client: PyEcotrendIsta) -> None:
     """Test `get_support_code` method."""
 
+    ista_client.login()
     assert ista_client.get_support_code() == "XXXXXXXXX"
+
+@pytest.mark.usefixtures("mock_requests_login")
+def test_get_support_code_returns_none(ista_client: PyEcotrendIsta) -> None:
+    """Test `get_support_code` method."""
+
+    assert ista_client.get_support_code() is None
 
 
 @pytest.mark.parametrize(("access_token", "expected_result"), [("ACCESS_TOKEN", True), (None, False)])


### PR DESCRIPTION
- Fixed `get_support_code` method to properly return the support code using `getattr`.
- Updated the docstring of `__set_account` to include error handling details.
- Added deprecation notice for `forceLogin` parameter in the `login` method's docstring.
- Corrected return type annotations for methods to use `ConsumptionsResponse`.
- Updated tests:
  - Added `test_get_support_code_returns_none` to verify `get_support_code` returns None when `_account` is not set.
  - Removed `xfail` marker from `test_get_support_code` as the method `get_support_code` os now fixed.