### PR TITLE
Add type hints for consumption unit details

### DIFF
--- a/src/pyecotrend_ista/pyecotrend_ista.py
+++ b/src/pyecotrend_ista/pyecotrend_ista.py
@@ -14,7 +14,7 @@ from .const import API_BASE_URL, DEMO_USER_ACCOUNT, VERSION
 from .exception_classes import KeycloakError, LoginError, ParserError, ServerError, deprecated
 from .helper_object_de import CustomRaw
 from .login_helper import LoginHelper
-from .types import AccountResponse, ConsumptionsResponse, GetTokenResponse
+from .types import AccountResponse, ConsumptionsResponse, ConsumptionUnitDetailsResponse, GetTokenResponse
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -870,12 +870,12 @@ class PyEcotrendIsta:
 
     get_raw = deprecated(get_comsumption_data, "get_raw")
 
-    def get_consumption_unit_details(self) -> dict[str, Any]:
+    def get_consumption_unit_details(self) -> ConsumptionUnitDetailsResponse:
         """Retrieve details of the consumption unit from the API.
 
         Returns
         -------
-        dict
+        ConsumptionUnitDetailsResponse
             A dictionary containing the details of the consumption unit.
 
         Raises
@@ -895,7 +895,7 @@ class PyEcotrendIsta:
 
                 r.raise_for_status()
                 try:
-                    return r.json()
+                    return cast(ConsumptionUnitDetailsResponse, r.json())
                 except requests.JSONDecodeError as exc:
                     raise ParserError(
                         "Loading consumption unit details failed due to an error parsing the request response"

--- a/src/pyecotrend_ista/types.py
+++ b/src/pyecotrend_ista/types.py
@@ -361,3 +361,89 @@ class ConsumptionsResponse(TypedDict, total=False):
     isSCEedBasicForCurrentMonth: bool
     nonEEDBasicStartDate: Any
     resident: dict[str, Any]
+
+
+
+class IstaConsumptionUnitAddress(TypedDict):
+    """Represents the address of a consumption unit.
+
+    Attributes
+    ----------
+    street : str
+        The street name of the address.
+    houseNumber : str
+        The house number of the address.
+    postalCode : str
+        The postal code of the address.
+    city : str
+        The city of the address.
+    country : str
+        The country code of the address.
+    floor : str
+        The floor number of the address.
+    propertyNumber : str
+        The property number of the address.
+    consumptionUnitNumber : str
+        The consumption unit number associated with the address.
+    idAtCustomerUser : str
+        The ID assigned to the address at the customer user's end.
+    """
+
+    street: str
+    houseNumber: str
+    postalCode: str
+    city: str
+    country: str # country code
+    floor: str
+    propertyNumber: str
+    consumptionUnitNumber: str
+    idAtCustomerUser: str
+
+class IstaConsumptionUnitBookedServices(TypedDict):
+    """Represents the booked extra services for an Ista consumption unit.
+
+    Attributes
+    ----------
+    cost : bool
+        Indicates if cost service is booked.
+    co2 : bool
+        Indicates if CO2 service is booked.
+    """
+
+    cost: bool
+    co2: bool
+
+class IstaConsumptionUnit(TypedDict):
+    """Represents a consumption unit.
+
+    Attributes
+    ----------
+    id : str
+        The UUID of the consumption unit.
+    address : IstaConsumptionUnitAddress
+        The address details of the consumption unit.
+    booked : IstaConsumptionUnitBookedServices
+        The booked services for the consumption unit.
+    propertyNumber : str
+        The property number associated with the consumption unit.
+    """
+
+    id: str # UUID
+    address: IstaConsumptionUnitAddress
+    booked: IstaConsumptionUnitBookedServices
+    propertyNumber: str
+
+
+class ConsumptionUnitDetailsResponse(TypedDict):
+    """Represents the response details for consumption units.
+
+    Attributes
+    ----------
+    consumptionUnits : list[IstaConsumptionUnit]
+        The list of consumption units.
+    coBranding : Any
+        Co-branding information (data type unknown).
+    """
+
+    consumptionUnits: list[IstaConsumptionUnit]
+    coBranding: Any # #unknown


### PR DESCRIPTION
- Update `get_consumption_unit_details` method to return `ConsumptionUnitDetailsResponse`.
- Add `ConsumptionUnitDetailsResponse` TypedDict class.
- Change the return type of `get_consumption_unit_details` to `ConsumptionUnitDetailsResponse`.