### PR TITLE
Remove pytest-datadir dependency

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,6 @@
 pytest==8.2.2
 pytest-cov==5.0.0
-pytest-dataset==0.3.2
+pytest-datadir==1.5.0
 pytest-xdist==3.6.1
 requests-mock[fixture]==1.12.1
 syrupy==4.6.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,5 @@
 pytest==8.2.2
 pytest-cov==5.0.0
-pytest-datadir==1.5.0
 pytest-xdist==3.6.1
 requests-mock[fixture]==1.12.1
 syrupy==4.6.1

--- a/src/pyecotrend_ista/const.py
+++ b/src/pyecotrend_ista/const.py
@@ -1,6 +1,6 @@
 """Constants for PyEcotrendIsta."""
 
-VERSION = "3.3.0"
+VERSION = "3.3.1"
 
 API_BASE_URL = "https://api.prod.eed.ista.com/"
 

--- a/src/pyecotrend_ista/const.py
+++ b/src/pyecotrend_ista/const.py
@@ -1,6 +1,6 @@
 """Constants for PyEcotrendIsta."""
 
-VERSION = "3.3.1"
+VERSION = "3.3.2"
 
 API_BASE_URL = "https://api.prod.eed.ista.com/"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Fixtures for Tests."""
 
 from http import HTTPStatus
+from pathlib import Path
 
 import pytest
 from requests_mock.mocker import Mocker as RequestsMock
@@ -11,6 +12,13 @@ from pyecotrend_ista.const import API_BASE_URL, DEMO_USER_ACCOUNT, PROVIDER_URL
 TEST_EMAIL = "max.istamann@test.com"
 DEMO_EMAIL = DEMO_USER_ACCOUNT
 TEST_PASSWORD = "password"
+
+@pytest.fixture
+def json_data(request) -> str:
+    """Load json test data."""
+    file = getattr(request, "param", "test_data")
+    path = Path(__file__).parent / "data" / f"{file}.json"
+    return path.read_text(encoding="utf-8")
 
 
 @pytest.fixture

--- a/tests/test_consumptions.py
+++ b/tests/test_consumptions.py
@@ -12,10 +12,10 @@ from pyecotrend_ista import LoginError, ParserError, PyEcotrendIsta, ServerError
 from pyecotrend_ista.const import API_BASE_URL
 
 
-def test_get_comsumption_data(ista_client: PyEcotrendIsta, requests_mock: RequestsMock, snapshot: SnapshotAssertion, dataset) -> None:
+def test_get_comsumption_data(ista_client: PyEcotrendIsta, requests_mock: RequestsMock, snapshot: SnapshotAssertion, shared_datadir) -> None:
     """Test `_set_account` method."""
 
-    requests_mock.get(f"{API_BASE_URL}consumptions", json=dataset["test_data"])
+    requests_mock.get(f"{API_BASE_URL}consumptions", text=(shared_datadir / "test_data.json").read_text())
 
     assert ista_client.get_consumption_data("26e93f1a-c828-11ea-87d0-0242ac130003") == snapshot
 
@@ -59,10 +59,10 @@ def test_get_comsumption_data_exceptions(requests_mock: RequestsMock, ista_clien
         ista_client.get_consumption_data("26e93f1a-c828-11ea-87d0-0242ac130003")
 
 
-def test_consum_raw(ista_client: PyEcotrendIsta, requests_mock: RequestsMock, snapshot: SnapshotAssertion, dataset) -> None:
+def test_consum_raw(ista_client: PyEcotrendIsta, requests_mock: RequestsMock, snapshot: SnapshotAssertion, shared_datadir) -> None:
     """Test `cunsum_raw` method."""
 
-    requests_mock.get(f"{API_BASE_URL}consumptions", json=dataset["test_data"])
+    requests_mock.get(f"{API_BASE_URL}consumptions", text=(shared_datadir / "test_data.json").read_text())
     result = ista_client.consum_raw(obj_uuid="26e93f1a-c828-11ea-87d0-0242ac130003")
 
     # consum_raw returns consum_types list in random order, so we exclude it from snapshot matcher
@@ -112,14 +112,14 @@ def test_consum_raw_filters(
     ista_client: PyEcotrendIsta,
     requests_mock: RequestsMock,
     snapshot: SnapshotAssertion,
-    dataset,
+    shared_datadir,
     select_year: list[int],
     select_month: list[int],
     filter_none: bool,
 ) -> None:
     """Test `cunsum_raw` method."""
 
-    requests_mock.get(f"{API_BASE_URL}consumptions", json=dataset["test_data"])
+    requests_mock.get(f"{API_BASE_URL}consumptions", text=(shared_datadir / "test_data.json").read_text())
     result = ista_client.consum_raw(
         obj_uuid="26e93f1a-c828-11ea-87d0-0242ac130003",
         select_year=select_year,

--- a/tests/test_consumptions.py
+++ b/tests/test_consumptions.py
@@ -12,10 +12,10 @@ from pyecotrend_ista import LoginError, ParserError, PyEcotrendIsta, ServerError
 from pyecotrend_ista.const import API_BASE_URL
 
 
-def test_get_comsumption_data(ista_client: PyEcotrendIsta, requests_mock: RequestsMock, snapshot: SnapshotAssertion, shared_datadir) -> None:
+def test_get_comsumption_data(ista_client: PyEcotrendIsta, requests_mock: RequestsMock, snapshot: SnapshotAssertion, json_data: str,) -> None:
     """Test `_set_account` method."""
 
-    requests_mock.get(f"{API_BASE_URL}consumptions", text=(shared_datadir / "test_data.json").read_text())
+    requests_mock.get(f"{API_BASE_URL}consumptions", text=json_data)
 
     assert ista_client.get_consumption_data("26e93f1a-c828-11ea-87d0-0242ac130003") == snapshot
 
@@ -59,10 +59,10 @@ def test_get_comsumption_data_exceptions(requests_mock: RequestsMock, ista_clien
         ista_client.get_consumption_data("26e93f1a-c828-11ea-87d0-0242ac130003")
 
 
-def test_consum_raw(ista_client: PyEcotrendIsta, requests_mock: RequestsMock, snapshot: SnapshotAssertion, shared_datadir) -> None:
+def test_consum_raw(ista_client: PyEcotrendIsta, requests_mock: RequestsMock, snapshot: SnapshotAssertion, json_data: str) -> None:
     """Test `cunsum_raw` method."""
 
-    requests_mock.get(f"{API_BASE_URL}consumptions", text=(shared_datadir / "test_data.json").read_text())
+    requests_mock.get(f"{API_BASE_URL}consumptions", text=json_data)
     result = ista_client.consum_raw(obj_uuid="26e93f1a-c828-11ea-87d0-0242ac130003")
 
     # consum_raw returns consum_types list in random order, so we exclude it from snapshot matcher
@@ -112,14 +112,14 @@ def test_consum_raw_filters(
     ista_client: PyEcotrendIsta,
     requests_mock: RequestsMock,
     snapshot: SnapshotAssertion,
-    shared_datadir,
+    json_data: str,
     select_year: list[int],
     select_month: list[int],
     filter_none: bool,
 ) -> None:
     """Test `cunsum_raw` method."""
 
-    requests_mock.get(f"{API_BASE_URL}consumptions", text=(shared_datadir / "test_data.json").read_text())
+    requests_mock.get(f"{API_BASE_URL}consumptions", text=json_data)
     result = ista_client.consum_raw(
         obj_uuid="26e93f1a-c828-11ea-87d0-0242ac130003",
         select_year=select_year,


### PR DESCRIPTION
While packaging `pyecotrend-ista ` for Nixpkgs, I had to package these two dependencies as well: `pytest-dataset` and `pyjson`.  Both seem to be pretty niche. This PR removes the dependency on `pytest-dataset` and replaces it with a similar invocation of `pytest-datadir`.
The mocked endpoint now returns the unmodified text of the mock file, without parsing it into an object. I have verified that the tests still work locally.

Note that this is merely a suggestion to make my life as a maintainer easier.