### PR TITLE
Fix Typo in RESPONSE_TYPE Variable Name

### DIFF
--- a/.github/actions/get_version.py
+++ b/.github/actions/get_version.py
@@ -37,7 +37,7 @@ def main():
     Examples
     --------
     >>> main()
-    3.3.2
+    3.3.3
     0
     """
     spec = importlib.util.spec_from_file_location("pyecotrend_ista.__version__", "./src/pyecotrend_ista/__version.py")

--- a/src/pyecotrend_ista/__version.py
+++ b/src/pyecotrend_ista/__version.py
@@ -1,3 +1,3 @@
 """Module containing the version information for the project."""  # numpydoc ignore=EX01,ES01
 
-__version__ = "3.3.2"
+__version__ = "3.3.3"

--- a/src/pyecotrend_ista/const.py
+++ b/src/pyecotrend_ista/const.py
@@ -13,7 +13,7 @@ REDIRECT_URI = "https://ecotrend.ista.de/login-redirect"
 CLIENT_ID = "ecotrend"
 SCOPE = "openid"
 RESPONSE_MODE = "fragment"
-RESPONSE_TPYE = "code"
+RESPONSE_TYPE = "code"
 GRANT_TYPE_REFRESH_TOKEN = "refresh_token"
 GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code"
 

--- a/src/pyecotrend_ista/login_helper.py
+++ b/src/pyecotrend_ista/login_helper.py
@@ -19,7 +19,7 @@ from .const import (
     PROVIDER_URL,
     REDIRECT_URI,
     RESPONSE_MODE,
-    RESPONSE_TPYE,
+    RESPONSE_TYPE,
     SCOPE,
     TIMEOUT,
 )
@@ -224,7 +224,7 @@ class LoginHelper:  # numpydoc ignore=ES01,EX01,PR01
             url=f"{PROVIDER_URL}auth",
             params={
                 "response_mode": RESPONSE_MODE,  # fragment
-                "response_type": RESPONSE_TPYE,  # code
+                "response_type": RESPONSE_TYPE,  # code
                 "client_id": CLIENT_ID,
                 "scope": SCOPE,
                 "redirect_uri": REDIRECT_URI,


### PR DESCRIPTION
This pull request corrects a typo in the `login_helper.py` file, where `RESPONSE_TPYE` was incorrectly spelled. The variable name has been updated to `RESPONSE_TYPE` to ensure consistency and accuracy in the authentication process. This change fixes the parameter used in the authentication URL construction, ensuring proper functionality.