### PR TITLE
ci: integrate GitHub merge queue triggers

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,7 +7,7 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 name: "Dependency Review"
-on: [pull_request]
+on: [pull_request, merge_group]
 
 permissions:
   contents: read

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,6 +3,8 @@ name: documentation
 on:
   pull_request:
     branches: ["main"]
+  merge_group:
+    types: [checks_requested]
   push:
     branches: ["main"]
   workflow_dispatch:
@@ -40,7 +42,7 @@ jobs:
           pip install .[doc]
 
       - name: Build documentation
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         run: |
           tox -e documentation
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,6 +7,8 @@ on:
     #   - ".github/**"
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read


### PR DESCRIPTION
### Motivation
- Ensure required CI checks run for GitHub Merge Queue batches so queued PRs are not blocked by missing status checks. 
- Make dependency scanning and documentation validation run for `merge_group` events in the same way they do for `pull_request` events.

### Description
- Added a `merge_group` trigger with `types: [checks_requested]` to `.github/workflows/pytest.yml` so test matrix runs for merge-queue batches. 
- Added a `merge_group` trigger to `.github/workflows/documentation.yml` and updated the documentation step condition to run when `github.event_name == 'pull_request' || github.event_name == 'merge_group'`. 
- Updated `.github/workflows/dependency-review.yml` to include `merge_group` in the `on:` list so dependency review runs for merge-queue events.

### Testing
- No automated tests were run locally because the changes are limited to workflow triggers; the modifications will be validated when GitHub Actions run the workflows for `merge_group` events in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12a1d96c4483258eab740ec867bed2)