### PR TITLE
Use tox_env matrix and bump tox to 4.54.0

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,7 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.11", "3.12", "3.13", "3.14"]
+        include:
+          - python_version: "3.11"
+            tox_env: "py311"
+          - python_version: "3.12"
+            tox_env: "py312"
+          - python_version: "3.13"
+            tox_env: "py313"
+          - python_version: "3.14"
+            tox_env: "py314"
 
     steps:
       - name: Harden Runner
@@ -36,7 +44,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install .[test]
       - name: Run tests with tox
-        run: tox -e py${{ matrix.python_version }}
+        run: tox -e ${{ matrix.tox_env }}
       - uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,12 +62,12 @@ doc = [
   "pygments==2.19.2",
   "python-dateutil==2.9.0.post0",
   "pytz==2025.2",
-  "tox==4.30.3",
+  "tox==4.54.0",
   "regex==2025.9.18",
   "watchdog==6.0.0"
 ]
 publish = [
-  "tox==4.30.3"
+  "tox==4.54.0"
 ]
 test = [
   "pytest==8.4.1",
@@ -75,7 +75,7 @@ test = [
   "pytest-xdist==3.8.0",
   "requests-mock[fixture]==1.12.1",
   "syrupy==5.0.0",
-  "tox==4.30.3"
+  "tox==4.54.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
Update GitHub Actions test matrix to include a tox_env mapping per Python version and run tox using matrix.tox_env (e.g. py311, py312, etc.). Also bump tox from 4.30.3 to 4.54.0 in pyproject.toml (doc, publish, and test extras) to keep CI and tooling in sync.