### PR TITLE
Improve CI automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,14 @@ updates:
       interval: daily
       time: "22:30"
       timezone: "Europe/Berlin"
-    open-pull-requests-limit: 50
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - github_actions
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: pip
     directory: /
@@ -14,4 +21,11 @@ updates:
       interval: daily
       time: "22:30"
       timezone: "Europe/Berlin"
-    open-pull-requests-limit: 50
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - python
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -43,3 +43,12 @@
 - name: "Beta"
   description: Beta Version Release
   color: d73a4a
+- name: dependencies
+  description: Dependency updates
+  color: 0366d6
+- name: python
+  description: Python dependency updates
+  color: 3572A5
+- name: github_actions
+  description: GitHub Actions dependency updates
+  color: 2088FF

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,35 @@
+name: Auto-merge Dependabot
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    name: Enable auto-merge
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.5.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for safe updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ############################
   # BUILDING THE DOCUMENTATION
@@ -36,6 +40,11 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+            tox.ini
 
       - name: Installing pip packages
         run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,39 @@
+name: Pre-commit checks
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: .pre-commit-config.yaml
+
+      - name: Run pre-commit
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        with:
+          extra_args: --all-files --show-diff-on-failure

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -39,12 +43,23 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python_version }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            tox.ini
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install .[test]
       - name: Run tests with tox
         run: tox -e ${{ matrix.tox_env }}
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-${{ matrix.tox_env }}
+          path: coverage.xml
+          if-no-files-found: error
+
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Motivation
- Reduce Dependabot noise and enable safe auto-merges, add pre-commit checks on PRs, and speed up CI with caching and concurrency.

### Description
- Updated `.github/dependabot.yml` to lower `open-pull-requests-limit`, add dependency labels and group patterns for GitHub Actions and pip updates.
- Added labels in `.github/labels.yml` for `dependencies`, `python`, and `github_actions` to match Dependabot labeling.
- Added `.github/workflows/auto-merge-dependabot.yml` to auto-merge non-major Dependabot updates when safe.
- Added `.github/workflows/pre-commit.yml` and updated `.github/workflows/pytest.yml` and `.github/workflows/documentation.yml` to enable `concurrency`, add pip caching, and upload coverage artifacts per matrix job.

### Testing
- Validated all GitHub YAML files with `python` and `yaml.safe_load`, which completed successfully.
- Ran `pytest --cov=src/pyecotrend_ista --cov-report=xml --cov-report=term-missing tests`, which produced `444 passed` and wrote `coverage.xml` (total coverage reported ~88%).
- `tox -e py311` was skipped because the container does not provide a `py311` interpreter.
- `tox -e pre-commit` could not complete due to an environment `npm` error (`SELF_SIGNED_CERT_IN_CHAIN`) while installing the `prettier` pre-commit dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b76247e948325a184ebaa6088236d)