### PR TITLE
Group CodeQL action Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       time: "22:30"
       timezone: "Europe/Berlin"
     open-pull-requests-limit: 50
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
 
   - package-ecosystem: pip
     directory: /


### PR DESCRIPTION
### Motivation
- Group Dependabot updates for the CodeQL GitHub Action so related action updates are opened as a single grouped PR instead of separate PRs.

### Description
- Add `groups.codeql-action` with `patterns: ["github/codeql-action*"]` to the `github-actions` entry in `.github/dependabot.yml`.

### Testing
- Ran a YAML parse/assert using `yaml.safe_load` to verify `data['updates'][0]['groups']['codeql-action']['patterns'] == ['github/codeql-action*']`, and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50eebb43d883259656e4ef571274b2)