### PR TITLE
ci: run CodeQL in merge queue

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,8 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   schedule:
     - cron: "31 12 * * 0"
 


### PR DESCRIPTION
### Motivation
- Enable CodeQL to run for merge-queue validation by adding a `merge_group` trigger so CodeQL checks are executed when merge-group checks are requested.

### Description
- Add `merge_group: types: [checks_requested]` to the `on` triggers in `.github/workflows/codeql-analysis.yml` so the workflow runs for merge-group (merge queue) events.

### Testing
- Ran `git diff --check` and parsed the GitHub Actions workflow YAML files with PyYAML which succeeded, while `pre-commit run check-yaml --files .github/workflows/codeql-analysis.yml` could not be executed because the `pre-commit` executable is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f2202f9fc8325af7c20daa1fb77a7)